### PR TITLE
Change how MessageReader assigns its type

### DIFF
--- a/QuickLink/Messages/MessageReader.cs
+++ b/QuickLink/Messages/MessageReader.cs
@@ -22,10 +22,11 @@ namespace QuickLink.Messaging
         /// <param name="buffer">The byte buffer to read from.</param>
         public MessageReader(byte[] buffer)
         {
-            _buffer = buffer;
+            _buffer = new byte[buffer.Length - 4];
+            Array.Copy(buffer, 4, _buffer, 0, _buffer.Length);
             _offset = 0;
 
-            Type = MessageType.Get(ReadUInt32());
+            Type = MessageType.Get(BitConverter.ToUInt32(buffer, 0));
         }
 
         private void EnsureCanReadLength(int length)

--- a/QuickLink/Messages/MessageType.cs
+++ b/QuickLink/Messages/MessageType.cs
@@ -21,6 +21,12 @@ namespace QuickLink.Messaging
         /// </summary>
         public string Name { get; private set; }
 
+        private MessageType(uint id)
+        {
+            Id = id;
+            Name = "UNKNOWN";
+        }
+
         /// <summary>
         /// Gets the message type with the specified identifier.
         /// </summary>
@@ -28,13 +34,15 @@ namespace QuickLink.Messaging
         /// <returns>The message type with the specified identifier.</returns>
         public static MessageType Get(uint id)
         {
-            return _messageTypes[id];
-        }
+            lock (_lock)
+            {
+                if (!_messageTypes.ContainsKey(id))
+                {
+                    _messageTypes.Add(id, new MessageType(id));
+                }
 
-        private MessageType(uint id, string name)
-        {
-            Id = id;
-            Name = name;
+                return _messageTypes[id];
+            }
         }
 
         /// <summary>
@@ -48,12 +56,14 @@ namespace QuickLink.Messaging
             lock (_lock)
             {
                 uint id = CRC32.GenerateHash(name);
-                if (!_messageTypes.ContainsKey(id))
+                MessageType messageType = Get(id);
+
+                if (messageType.Name == "UNKNOWN")
                 {
-                    _messageTypes.Add(id, new MessageType(id, name));
+                    messageType.Name = name;
                 }
 
-                return _messageTypes[id];
+                return messageType;
             }
         }
     }


### PR DESCRIPTION
Modified MessageReader to dismiss the four byte header for the message type into its buffer.
This allows proper seeking in the message.

Resolves #5